### PR TITLE
Fix old-style yakuman data parsing with double LF character

### DIFF
--- a/server/player/tenhou/management/commands/update_tenhou_yakuman.py
+++ b/server/player/tenhou/management/commands/update_tenhou_yakuman.py
@@ -97,7 +97,7 @@ class Command(BaseCommand):
             yakuman_data = json.loads(yakuman_data[4:-1].replace('"', '\\"').replace("'", '"'))
         # old format
         else:
-            yakuman_data = yakuman_data.split(';\n')[2]
+            yakuman_data = yakuman_data.split(';\n')[2].strip()
             yakuman_data = yakuman_data[4:].replace('"', '\\"').replace("'", '"').replace('\n', '')
             yakuman_data = json.loads(yakuman_data)
 


### PR DESCRIPTION
Some files downloaded from tenhou.net have ";\n\n" in them.
Index logic failed here.