### PR TITLE
issue1_add i18n_patterns to urls

### DIFF
--- a/server/mahjong_portal/urls.py
+++ b/server/mahjong_portal/urls.py
@@ -75,6 +75,7 @@ urlpatterns = [
     url("^api/v0/autobot/add_penalty_game$", add_penalty_game),
     url("^api/v0/autobot/send_team_names_to_pantheon$", send_team_names_to_pantheon),
     url(r"^online/", include("online.urls")),
+    url('i18n/', include('django.conf.urls.i18n')),
 ]
 
 urlpatterns += i18n_patterns(
@@ -90,4 +91,5 @@ urlpatterns += i18n_patterns(
     url(r"^account/", include("account.urls")),
     url(r"^wiki/", include("wiki.urls")),
     url(r"^league/", include("league.urls")),
+    url('i18n/', include('django.conf.urls.i18n')),
 )


### PR DESCRIPTION
Иногда язык не переключается как с ru на eng, так и наоборот.

браузер mozila firefox 137.0.2 (64-разрядный)
Алгоритм воспроизведения:
1. открыть новую вкладку
2. скопировать ссылку  https://mahjong.click/en/players/ermolaev-andrei/tenhou/ в адресную строку
3. перейти по ссылке 
4. сменить язык на ру
ОР: язык страницы изменился на ру
ФР: язык страницы не изменился

Иногда может не сработать, тогда можно рядом создать ещё одну вкладку и повторить аналогичные действия.

deepseek говорит, что это может быть из-за пропущенных переводных паттернов i18n_patterns.
я добавил две строки в urls и действительно, проблема исчезла.