### PR TITLE
Pantheon ids fixes, part 3

### DIFF
--- a/server/tournament/management/commands/add_pantheon_ids_to_tournament_results.py
+++ b/server/tournament/management/commands/add_pantheon_ids_to_tournament_results.py
@@ -161,6 +161,7 @@ def update_db(tournament: Tournament, clean_old: bool, update: bool, parsed_reco
 
     objects_to_update: List[TournamentResult] = []
     null_player_count = 0
+    replacement_player_count = 0
     already_set_count = 0
     wrongly_set_count = 0
     manual_count = 0
@@ -181,6 +182,15 @@ def update_db(tournament: Tournament, clean_old: bool, update: bool, parsed_reco
                 continue
 
             player_pantheon_id: int = parsed_record.player_pantheon_id
+
+            if tournament_result.player.is_replacement:
+                print(
+                    f"Place {tournament_result.place} (score {score}) "
+                    f"has replacement player (portal name {tournament_result.player.full_name}), can't process it "
+                    f"(player pantheon id {player_pantheon_id}, parsed name {parsed_record.player_name})"
+                )
+                replacement_player_count += 1
+                continue
 
             if tournament_result.player_pantheon_id is not None:
                 if tournament_result.player_pantheon_id == player_pantheon_id:
@@ -222,6 +232,8 @@ def update_db(tournament: Tournament, clean_old: bool, update: bool, parsed_reco
                 for tournament_result in tournament_results_for_score:
                     if tournament_result.player is None:
                         null_player_count += 1
+                    elif tournament_result.player.is_replacement:
+                        replacement_player_count += 1
                     else:
                         suitable_count += 1
                         if tournament_result.player_pantheon_id is not None:
@@ -260,7 +272,8 @@ def update_db(tournament: Tournament, clean_old: bool, update: bool, parsed_reco
                 wrongly_set_count += suitable_count
 
     print(
-        f"To update: {len(objects_to_update)}, null players: {null_player_count}, "
+        f"To update: {len(objects_to_update)}, "
+        f"null players: {null_player_count}, replacement players: {replacement_player_count}, "
         f"already set: {already_set_count}, wrongly set: {wrongly_set_count}, manual: {manual_count}"
     )
 

--- a/server/website/views.py
+++ b/server/website/views.py
@@ -265,7 +265,7 @@ def extract_tournament_data(tournaments, pantheon_type):
         for res in tournament.results.all().order_by("place"):
             player_dict = {}
             player_dict["place"] = res.place
-            player_dict["score"] = round(float(res.scores), ndigits=2)
+            player_dict["score"] = round(float(res.scores), ndigits=2) if res.scores else None
             if res.player_pantheon_id:
                 player_dict["player_pantheon_id"] = res.player_pantheon_id
             if res.player:

--- a/server/website/views.py
+++ b/server/website/views.py
@@ -251,17 +251,15 @@ def finished_tournaments_api(request):
             if tournament.new_pantheon_id is not None:
                 new_pantheon_tournaments.append(tournament)
 
-    new_pantheon_tournaments = sorted(new_pantheon_tournaments, key=lambda x: x.new_pantheon_id, reverse=False)
-    old_pantheon_tournaments = sorted(old_pantheon_tournaments, key=lambda x: x.old_pantheon_id, reverse=False)
-
     data = []
-    aggregate_tournaments(new_pantheon_tournaments, NEW_PANTHEON_TYPE, data)
-    aggregate_tournaments(old_pantheon_tournaments, OLD_PANTHEON_TYPE, data)
+    data += extract_tournament_data(old_pantheon_tournaments, OLD_PANTHEON_TYPE)
+    data += extract_tournament_data(new_pantheon_tournaments, NEW_PANTHEON_TYPE)
 
     return JsonResponse(data, safe=False)
 
 
-def aggregate_tournaments(tournaments, pantheon_type, result):
+def extract_tournament_data(tournaments, pantheon_type):
+    result = []
     for tournament in tournaments:
         players = []
         for res in tournament.results.all().order_by("place"):
@@ -284,6 +282,8 @@ def aggregate_tournaments(tournaments, pantheon_type, result):
                 "players": players,
             }
         )
+    result.sort(key=lambda x: x["pantheon_id"])
+    return result
 
 
 def extract_pantheon_id(tournament, pantheon_type):

--- a/server/website/views.py
+++ b/server/website/views.py
@@ -267,7 +267,7 @@ def aggregate_tournaments(tournaments, pantheon_type, result):
         for res in tournament.results.all().order_by("place"):
             player_dict = {}
             player_dict["place"] = res.place
-            player_dict["score"] = res.scores
+            player_dict["score"] = round(float(res.scores), ndigits=2)
             if res.player_pantheon_id:
                 player_dict["player_pantheon_id"] = res.player_pantheon_id
             if res.player:


### PR DESCRIPTION
Сделал, чтобы игрокам замены не проставлялась ссылка (а то потом она в trueskill прорастет, и там неудобно с ней возиться).

Я хотел поддерживать, что ссылка проставляется только тем игрокам, у которых есть профиль на портале, так вот оказалось, что у игрока замены тоже есть профиль, но он проифан и поэтому рендерится не ссылкой.

Также улучшил вывод апишки (score теперь число, и сортировка правильная)