### PR TITLE
Faster rating calculation

### DIFF
--- a/server/rating/calculation/rr.py
+++ b/server/rating/calculation/rr.py
@@ -3,6 +3,7 @@
 import itertools
 import math
 from datetime import timedelta
+from typing import Collection
 
 from dateutil.relativedelta import relativedelta
 from django.db.models import Q
@@ -121,7 +122,12 @@ class RatingRRCalculation:
             if num_tournaments == total_tournaments:
                 tournaments_results = deltas
                 best_rating_calculation, best_score = self._calculate_player_rating(
-                    player, tournaments_results, deltas, coefficients_cache, max_coefficient, selected_coefficients
+                    player=player,
+                    tournaments_results=tournaments_results,
+                    deltas=deltas,
+                    coefficients_cache=coefficients_cache,
+                    max_coefficient=max_coefficient,
+                    selected_coefficients=selected_coefficients,
                 )
                 best_tournament_results_option = tournaments_results
             else:
@@ -131,12 +137,12 @@ class RatingRRCalculation:
 
                 for tournaments_results_option in itertools.combinations(deltas, num_tournaments):
                     rating_calculation, score = self._calculate_player_rating(
-                        player,
-                        tournaments_results_option,
-                        deltas,
-                        coefficients_cache,
-                        max_coefficient,
-                        selected_coefficients,
+                        player=player,
+                        tournaments_results=tournaments_results_option,
+                        deltas=deltas,
+                        coefficients_cache=coefficients_cache,
+                        max_coefficient=max_coefficient,
+                        selected_coefficients=selected_coefficients,
                     )
                     if score >= best_score:
                         best_score = score
@@ -331,12 +337,43 @@ class RatingRRCalculation:
             return 0
 
     def _calculate_player_rating(
-        self, player, tournaments_results, deltas, coefficients_cache, max_coefficient, selected_coefficients
-    ):
+        self,
+        player: Player,
+        tournaments_results: Collection[RatingDelta],
+        deltas: list[RatingDelta],
+        coefficients_cache: dict[int, TournamentCoefficients],
+        max_coefficient: float,
+        selected_coefficients: list[dict[str, float]],
+    ) -> tuple[str, float]:
+        first_part_calculation, first_part = self._calculate_player_rating_first_part(
+            player=player,
+            tournaments_results=tournaments_results,
+            coefficients_cache=coefficients_cache,
+        )
+        max_coefficient_template, second_part_calculation, second_part = self._calculate_player_rating_second_part(
+            player=player,
+            deltas=deltas,
+            coefficients_cache=coefficients_cache,
+            max_coefficient=max_coefficient,
+            selected_coefficients=selected_coefficients,
+        )
+        rating_calculation, score = self._join_player_rating_parts(
+            max_coefficient_template=max_coefficient_template,
+            first_part_calculation=first_part_calculation,
+            second_part_calculation=second_part_calculation,
+            first_part=first_part,
+            second_part=second_part,
+        )
+        return rating_calculation, score
+
+    def _calculate_player_rating_first_part(
+        self,
+        player: Player,
+        tournaments_results: Collection[RatingDelta],
+        coefficients_cache: dict[int, TournamentCoefficients],
+    ) -> tuple[str, float]:
         first_part_numerator_calculation = []
         first_part_denominator_calculation = []
-
-        second_part_numerator_calculation = []
 
         first_part_numerator = 0
         first_part_denominator = 0
@@ -372,6 +409,21 @@ class RatingRRCalculation:
 
         first_part = first_part_numerator / first_part_denominator
 
+        first_part_calculation = "p1 = ({}) / ({}) = {}".format(
+            " + ".join(first_part_numerator_calculation), " + ".join(first_part_denominator_calculation), first_part
+        )
+        return first_part_calculation, first_part
+
+    def _calculate_player_rating_second_part(
+        self,
+        player: Player,
+        deltas: list[RatingDelta],
+        coefficients_cache: dict[int, TournamentCoefficients],
+        max_coefficient: float,
+        selected_coefficients: list[dict[str, float]],
+    ) -> tuple[str, str, float]:
+        second_part_numerator_calculation = []
+
         second_part_numerator = 0
         second_part_denominator = max_coefficient
 
@@ -394,10 +446,6 @@ class RatingRRCalculation:
 
         second_part = second_part_numerator / second_part_denominator
 
-        score = self._calculate_percentage(first_part, self.FIRST_PART_WEIGHT) + self._calculate_percentage(
-            second_part, self.SECOND_PART_WEIGHT
-        )
-
         max_coefficient_calculation = []
         for x in selected_coefficients:
             max_coefficient_calculation.append(
@@ -406,11 +454,21 @@ class RatingRRCalculation:
         max_coefficient_template = "max_coefficients = ({}) = {}".format(
             " + ".join(max_coefficient_calculation), max_coefficient
         )
-        first_part_calculation = "p1 = ({}) / ({}) = {}".format(
-            " + ".join(first_part_numerator_calculation), " + ".join(first_part_denominator_calculation), first_part
-        )
         second_part_calculation = "p2 = ({}) / max_coefficients = {}".format(
             " + ".join(second_part_numerator_calculation), second_part
+        )
+        return max_coefficient_template, second_part_calculation, second_part
+
+    def _join_player_rating_parts(
+        self,
+        max_coefficient_template: str,
+        first_part_calculation: str,
+        second_part_calculation: str,
+        first_part: float,
+        second_part: float,
+    ) -> tuple[str, float]:
+        score = self._calculate_percentage(first_part, self.FIRST_PART_WEIGHT) + self._calculate_percentage(
+            second_part, self.SECOND_PART_WEIGHT
         )
         total_calculation = "score = {} * {} + {} * {} = {}".format(
             first_part, self.FIRST_PART_WEIGHT / 100, second_part, self.SECOND_PART_WEIGHT / 100, score
@@ -418,7 +476,6 @@ class RatingRRCalculation:
         rating_calculation = "\n\n".join(
             (max_coefficient_template, first_part_calculation, second_part_calculation, total_calculation)
         )
-
         return rating_calculation, score
 
     def _assume_number_of_sessions(self, tournament):

--- a/server/rating/calculation/rr.py
+++ b/server/rating/calculation/rr.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import itertools
 import math
 from datetime import timedelta
-from typing import Collection
 
 from dateutil.relativedelta import relativedelta
 from django.db.models import Q
@@ -119,36 +117,14 @@ class RatingRRCalculation:
             else:
                 num_tournaments = self._determine_tournaments_number(total_tournaments)
 
-            if num_tournaments == total_tournaments:
-                tournaments_results = deltas
-                best_rating_calculation, best_score = self._calculate_player_rating(
-                    player=player,
-                    tournaments_results=tournaments_results,
-                    deltas=deltas,
-                    coefficients_cache=coefficients_cache,
-                    max_coefficient=max_coefficient,
-                    selected_coefficients=selected_coefficients,
-                )
-                best_tournament_results_option = tournaments_results
-            else:
-                best_score = 0
-                best_rating_calculation = None
-                best_tournament_results_option = None
-
-                for tournaments_results_option in itertools.combinations(deltas, num_tournaments):
-                    rating_calculation, score = self._calculate_player_rating(
-                        player=player,
-                        tournaments_results=tournaments_results_option,
-                        deltas=deltas,
-                        coefficients_cache=coefficients_cache,
-                        max_coefficient=max_coefficient,
-                        selected_coefficients=selected_coefficients,
-                    )
-                    if score >= best_score:
-                        best_score = score
-                        best_rating_calculation = rating_calculation
-                        best_tournament_results_option = tournaments_results_option
-
+            best_rating_calculation, best_score, best_tournament_results_option = self._calculate_player_rating(
+                player=player,
+                num_tournaments=num_tournaments,
+                deltas=deltas,
+                coefficients_cache=coefficients_cache,
+                max_coefficient=max_coefficient,
+                selected_coefficients=selected_coefficients,
+            )
             RatingDelta.objects.filter(id__in=[x.id for x in best_tournament_results_option]).update(is_active=True)
 
             results.append(
@@ -339,15 +315,16 @@ class RatingRRCalculation:
     def _calculate_player_rating(
         self,
         player: Player,
-        tournaments_results: Collection[RatingDelta],
+        num_tournaments: int,
         deltas: list[RatingDelta],
         coefficients_cache: dict[int, TournamentCoefficients],
         max_coefficient: float,
         selected_coefficients: list[dict[str, float]],
-    ) -> tuple[str, float]:
-        first_part_calculation, first_part = self._calculate_player_rating_first_part(
+    ) -> tuple[str, float, list[RatingDelta]]:
+        first_part_calculation, first_part, best_tournament_results = self._calculate_player_rating_first_part(
             player=player,
-            tournaments_results=tournaments_results,
+            num_tournaments=num_tournaments,
+            deltas=deltas,
             coefficients_cache=coefficients_cache,
         )
         max_coefficient_template, second_part_calculation, second_part = self._calculate_player_rating_second_part(
@@ -364,14 +341,70 @@ class RatingRRCalculation:
             first_part=first_part,
             second_part=second_part,
         )
-        return rating_calculation, score
+        return rating_calculation, score, best_tournament_results
+
+    def _calculate_first_part_score(
+        self,
+        player: Player,
+        num_tournaments: int,
+        deltas: list[RatingDelta],
+        coefficients_cache: dict[int, TournamentCoefficients],
+    ) -> tuple[float, list[RatingDelta]]:
+        multipliers: list[float] = []
+        for delta in deltas:
+            coefficient_obj = coefficients_cache[delta.tournament_id]
+            coefficient = get_tournament_coefficient(
+                self.IS_EMA, coefficient_obj.tournament_id, player, coefficient_obj.coefficient
+            )
+            multiplier = float(self._calculate_percentage(float(coefficient), coefficient_obj.age))
+            multipliers.append(multiplier)
+
+        if len(deltas) <= num_tournaments:
+            numerator = 0.0
+            denominator = 0.0
+            for delta, multiplier in zip(deltas, multipliers, strict=True):
+                numerator += float(delta.delta)
+                denominator += multiplier
+            return numerator / denominator, deltas
+
+        # this problem can be solved by binary search
+        left_score = 0.0
+        right_score = 1000.0
+        for _ in range(80):
+            check_score = (left_score + right_score) / 2.0
+            values: list[float] = []
+            for delta, multiplier in zip(deltas, multipliers, strict=True):
+                values.append(float(delta.delta) - check_score * multiplier)
+            values.sort(reverse=True)
+            values = values[:num_tournaments]
+            if sum(values) >= 0.0:
+                left_score = check_score
+            else:
+                right_score = check_score
+
+        best_score = (left_score + right_score) / 2.0
+        best_values: list[tuple[float, RatingDelta]] = []
+        for delta, multiplier in zip(deltas, multipliers, strict=True):
+            best_values.append((float(delta.delta) - best_score * multiplier, delta))
+        best_values.sort(key=lambda t: t[0], reverse=True)
+        best_values = best_values[:num_tournaments]
+        return best_score, [t[1] for t in best_values]
 
     def _calculate_player_rating_first_part(
         self,
         player: Player,
-        tournaments_results: Collection[RatingDelta],
+        num_tournaments: int,
+        deltas: list[RatingDelta],
         coefficients_cache: dict[int, TournamentCoefficients],
-    ) -> tuple[str, float]:
+    ) -> tuple[str, float, list[RatingDelta]]:
+        _, tournaments_results = self._calculate_first_part_score(
+            player=player,
+            num_tournaments=num_tournaments,
+            deltas=deltas,
+            coefficients_cache=coefficients_cache,
+        )
+        assert len(tournaments_results) == num_tournaments
+
         first_part_numerator_calculation = []
         first_part_denominator_calculation = []
 
@@ -412,7 +445,7 @@ class RatingRRCalculation:
         first_part_calculation = "p1 = ({}) / ({}) = {}".format(
             " + ".join(first_part_numerator_calculation), " + ".join(first_part_denominator_calculation), first_part
         )
-        return first_part_calculation, first_part
+        return first_part_calculation, first_part, tournaments_results
 
     def _calculate_player_rating_second_part(
         self,

--- a/server/rating/tests/tests_inner.py
+++ b/server/rating/tests/tests_inner.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 
 from django.test import TestCase
 from django.utils import timezone
 
 from rating.calculation.crr import RatingCRRCalculation
+from rating.calculation.rr import RatingRRCalculation
 from rating.mixins import RatingTestMixin
 from rating.models import Rating, RatingDelta, RatingResult, TournamentCoefficients
 
@@ -301,3 +302,129 @@ class InnerRatingTestCase(TestCase, RatingTestMixin):
         delta_object = RatingResult.objects.get(player=self.player, rating=rating)
 
         self.assertEqual(float(delta_object.score), 342.86)
+
+    @classmethod
+    def _date(cls, date_str: str) -> date:
+        return datetime.fromisoformat(date_str).date()
+
+    def test_calculate_players_rating_algorithm_19(self):
+        rating, _ = Rating.objects.get_or_create(type=Rating.RR)
+        rating_date = self._date("2026-08-27")
+
+        tournaments_data = [
+            (self.create_tournament(end_date=self._date("2024-09-01"), sessions=10, players=96), 32),
+            (self.create_tournament(end_date=self._date("2024-10-13"), sessions=10, players=90), 39),
+            (self.create_tournament(end_date=self._date("2025-01-26"), sessions=8, players=43), 27),
+            (self.create_tournament(end_date=self._date("2025-02-02"), sessions=9, players=52), 31),
+            (self.create_tournament(end_date=self._date("2025-02-16"), sessions=9, players=60), 28),
+            (self.create_tournament(end_date=self._date("2025-05-03"), sessions=10, players=71), 2),
+            (self.create_tournament(end_date=self._date("2025-06-08"), sessions=8, players=16), 5),
+            (self.create_tournament(end_date=self._date("2025-06-15"), sessions=15, players=68), 31),
+            (self.create_tournament(end_date=self._date("2025-07-13"), sessions=9, players=31), 6),
+            (self.create_tournament(end_date=self._date("2025-08-03"), sessions=10, players=44), 12),
+            (self.create_tournament(end_date=self._date("2025-08-31"), sessions=9, players=78), 48),
+            (self.create_tournament(end_date=self._date("2025-11-04"), sessions=15, players=58), 3),
+            (self.create_tournament(end_date=self._date("2025-11-30"), sessions=12, players=32), 12),
+            (self.create_tournament(end_date=self._date("2026-01-25"), sessions=8, players=56), 5),
+            (self.create_tournament(end_date=self._date("2026-02-23"), sessions=9, players=75), 28),
+            (self.create_tournament(end_date=self._date("2026-04-05"), sessions=10, players=51), 13),
+            (self.create_tournament(end_date=self._date("2026-05-03"), sessions=10, players=43), 6),
+            (self.create_tournament(end_date=self._date("2026-06-14"), sessions=14, players=144), 58),
+            (self.create_tournament(end_date=self._date("2026-08-16"), sessions=10, players=60), 6),
+        ]
+
+        calculator = RatingRRCalculation()
+
+        for tournament, place in tournaments_data:
+            t_coef = calculator.tournament_coefficient(tournament)
+            t_age = calculator.tournament_age(tournament.end_date, rating_date)
+            t_score = ((tournament.number_of_players - place) / (tournament.number_of_players - 1)) * 1000
+            delta = calculator._calculate_percentage(t_coef * t_score, t_age)
+            self.create_rating_delta(rating, tournament, self.player, delta, rating_date)
+            TournamentCoefficients.objects.create(
+                rating=rating, tournament=tournament, coefficient=t_coef, age=t_age, date=rating_date
+            )
+
+        calculator.calculate_players_rating_rank(rating, rating_date)
+
+        delta_object = RatingResult.objects.get(player=self.player, rating=rating)
+
+        self.assertEqual(float(delta_object.score), 785.37)
+
+    def test_calculate_players_rating_algorithm_5(self):
+        rating, _ = Rating.objects.get_or_create(type=Rating.RR)
+        rating_date = self._date("2026-08-27")
+
+        # place == None -> not participated, but used for max_coefficient
+        tournaments_data = [
+            (self.create_tournament(end_date=self._date("2024-10-13"), sessions=10, players=90), 51),
+            (self.create_tournament(end_date=self._date("2025-05-03"), sessions=10, players=71), 23),
+            (self.create_tournament(end_date=self._date("2025-08-31"), sessions=9, players=78), None),
+            (self.create_tournament(end_date=self._date("2025-11-04"), sessions=15, players=58), None),
+            (self.create_tournament(end_date=self._date("2026-01-25"), sessions=8, players=56), 22),
+            (self.create_tournament(end_date=self._date("2026-06-14"), sessions=14, players=144), 17),
+            (self.create_tournament(end_date=self._date("2026-08-16"), sessions=10, players=60), 5),
+        ]
+
+        calculator = RatingRRCalculation()
+
+        another_player = self.create_player()
+        for tournament, place in tournaments_data:
+            t_coef = calculator.tournament_coefficient(tournament)
+            t_age = calculator.tournament_age(tournament.end_date, rating_date)
+            if place is not None:
+                t_score = ((tournament.number_of_players - place) / (tournament.number_of_players - 1)) * 1000
+                delta = calculator._calculate_percentage(t_coef * t_score, t_age)
+                self.create_rating_delta(rating, tournament, self.player, delta, rating_date)
+            else:
+                # for max_coefficient
+                delta = calculator._calculate_percentage(t_coef * 1000, t_age)
+                self.create_rating_delta(rating, tournament, another_player, delta, rating_date)
+            TournamentCoefficients.objects.create(
+                rating=rating, tournament=tournament, coefficient=t_coef, age=t_age, date=rating_date
+            )
+
+        calculator.calculate_players_rating_rank(rating, rating_date)
+
+        delta_object = RatingResult.objects.get(player=self.player, rating=rating)
+
+        self.assertEqual(float(delta_object.score), 747.54)
+
+    def test_calculate_players_rating_algorithm_4(self):
+        rating, _ = Rating.objects.get_or_create(type=Rating.RR)
+        rating_date = self._date("2026-08-27")
+
+        # place == None -> not participated, but used for max_coefficient
+        tournaments_data = [
+            (self.create_tournament(end_date=self._date("2025-01-26"), sessions=8, players=43), 13),
+            (self.create_tournament(end_date=self._date("2025-05-03"), sessions=10, players=71), 18),
+            (self.create_tournament(end_date=self._date("2025-08-31"), sessions=9, players=78), None),
+            (self.create_tournament(end_date=self._date("2025-11-04"), sessions=15, players=58), None),
+            (self.create_tournament(end_date=self._date("2026-01-25"), sessions=8, players=56), 3),
+            (self.create_tournament(end_date=self._date("2026-06-14"), sessions=14, players=144), 33),
+            (self.create_tournament(end_date=self._date("2026-08-16"), sessions=10, players=60), None),
+        ]
+
+        calculator = RatingRRCalculation()
+
+        another_player = self.create_player()
+        for tournament, place in tournaments_data:
+            t_coef = calculator.tournament_coefficient(tournament)
+            t_age = calculator.tournament_age(tournament.end_date, rating_date)
+            if place is not None:
+                t_score = ((tournament.number_of_players - place) / (tournament.number_of_players - 1)) * 1000
+                delta = calculator._calculate_percentage(t_coef * t_score, t_age)
+                self.create_rating_delta(rating, tournament, self.player, delta, rating_date)
+            else:
+                # for max_coefficient
+                delta = calculator._calculate_percentage(t_coef * 1000, t_age)
+                self.create_rating_delta(rating, tournament, another_player, delta, rating_date)
+            TournamentCoefficients.objects.create(
+                rating=rating, tournament=tournament, coefficient=t_coef, age=t_age, date=rating_date
+            )
+
+        calculator.calculate_players_rating_rank(rating, rating_date)
+
+        delta_object = RatingResult.objects.get(player=self.player, rating=rating)
+
+        self.assertEqual(float(delta_object.score), 673.39)


### PR DESCRIPTION
First part can be calculated without bruteforce (`itertools.combinations`).

It's a classical math problem "choose `k` of `n` items to maximize `sum(x[i]*w[i]) / sum(w[i])`".

Solution is a binary search.

Also, it opens a quick possible fix for smooth tournaments decay, which was discussed lately.
Just multiply the last element with 0.2 / 0.4 / 0.6 / 0.8 / 1.0